### PR TITLE
Make equals overridable to support different comparison logic

### DIFF
--- a/passcodeview/src/main/java/com/hanks/passcodeview/PasscodeView.java
+++ b/passcodeview/src/main/java/com/hanks/passcodeview/PasscodeView.java
@@ -297,6 +297,10 @@ public class PasscodeView extends FrameLayout implements View.OnClickListener {
         return this;
     }
 
+    protected Boolean equals(String val) {
+        return localPasscode.equals(val);
+    }
+
     private void next() {
         if (passcodeType == TYPE_CHECK_PASSCODE && TextUtils.isEmpty(localPasscode)) {
             throw new RuntimeException("must set localPasscode when type is TYPE_CHECK_PASSCODE");
@@ -318,7 +322,7 @@ public class PasscodeView extends FrameLayout implements View.OnClickListener {
             return;
         }
 
-        if (localPasscode.equals(psd)) {
+        if (equals(psd)) {
             // match
             runOkAnimation();
         } else {


### PR DESCRIPTION
Adding an override-able "equals" method enables you to switch out comparison logic.

I love the look and feel of the library but one of my top priorities is security, so I wanted to encrypt the passcode before saving, and then later use the encrypted user input to compare the two.

Instead of building the encryption into the library I thought a better approach is to just expose the comparison method so that the inherited classes can override it. 

For example I'm already using a library called SecurePreferences--which makes it easy to implement an encrypted version of SharedPreferences--in my project. So I simply need to extend `PasscodeView` and override the `equals` method. The end result looks something like this:

First, override the listener so that it encrypts the passcode before saving:

```
passcodeView.setListener(new PasscodeView.PasscodeViewListener() {
  @Override
  public void onFail() {
  }

  @Override
  public void onSuccess(String number) {
    String encrypted = SecurePreferences.hashPrefKey(raw);
    SharedPreferences.Editor editor = keys.edit();
    editor.putString("passcode", encrypted);
    editor.commit();
    finish();
  }
});
```

Second, compare using the overridden `equals()` method:

```
class PView extends PasscodeView {
  public PView(Context context) {
    super(context);
  }
  @Override protected Boolean equals(String psd) {
    String after = SecurePreferences.hashPrefKey(raw);
    return after.equals(encrypted_passcode);
  }
}
PView passcodeView = new PView(PasscodeActivity.this);
```

So far it's working fine for me without having to change much to the original library. What do you think?